### PR TITLE
Refactor alarm to wait until target time

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,35 +3,25 @@ import datetime
 import pygame
 
 
-def set_alarm(alarm_time):
-    print(f"Alarm set for {alarm_time}")
-    sound_file="alarm_clock/alarm.wav"
-    is_running=True
+def set_alarm(alarm_time_str):
+    """Set an alarm for the given time string in HH:MM:SS format."""
+    target = datetime.datetime.strptime(alarm_time_str, "%H:%M:%S")
+    now = datetime.datetime.now()
+    alarm_dt = now.replace(hour=target.hour, minute=target.minute, second=target.second, microsecond=0)
 
-    while is_running:
-        current_time=datetime.datetime.now().strftime("%H:%M:%S")
-        print(current_time)
+    if alarm_dt <= now:
+        alarm_dt += datetime.timedelta(days=1)
 
-        if alarm_time==current_time:
-            print("your time is up")
+    sleep_seconds = (alarm_dt - now).total_seconds()
+    print(f"Alarm set for {alarm_dt.strftime('%H:%M:%S')}")
+    time.sleep(sleep_seconds)
 
-            pygame.mixer.init()
-            pygame.mixer.music.load(sound_file)
-            pygame.mixer.music.play()
-            while pygame.mixer.music.get_busy():
-                time.sleep(1)
-            is_running=False
-
+    print("your time is up")
+    pygame.mixer.init()
+    pygame.mixer.music.load("alarm.wav")
+    pygame.mixer.music.play()
+    while pygame.mixer.music.get_busy():
         time.sleep(1)
-    
-
-
-
-
-
-
-
-
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- simplify alarm scheduling by computing sleep interval until target time
- initialize and play alarm sound after waiting

## Testing
- `python -m py_compile main.py`
- `python main.py <<EOF $future EOF` *(fails: ModuleNotFoundError: No module named 'pygame')*
- `pip install pygame` *(fails: Could not find a version that satisfies the requirement pygame: ProxyError: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c3e471325c8322b56bc208cb7eda5f